### PR TITLE
Improve SSL handling for SonarMetricsFetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,2 @@
-# Compiled class file
-*.class
+target/
 
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>sonar-metrics-fetcher</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/main/java/com/example/SonarMetricsFetcher.java
+++ b/src/main/java/com/example/SonarMetricsFetcher.java
@@ -1,0 +1,142 @@
+package com.example;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SonarMetricsFetcher {
+    private static final String SONAR_URL = "http://localhost:9000"; // change to your SonarQube URL
+    private static final String SONAR_TOKEN = "your_token_here"; // change to your token
+
+    private static final String METRICS = String.join(",",
+            "coverage",
+            "duplicated_lines_density",
+            "reliability_rating",
+            "security_rating",
+            "sqale_rating",
+            "new_coverage",
+            "new_duplicated_lines_density",
+            "new_reliability_rating",
+            "new_security_rating",
+            "new_maintainability_rating");
+
+    private final HttpClient client;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static final X509TrustManager TRUST_ALL_CERTS = new X509TrustManager() {
+        @Override
+        public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+            return new java.security.cert.X509Certificate[0];
+        }
+    };
+
+    public SonarMetricsFetcher() {
+        SSLContext sslContext;
+        try {
+            sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, new TrustManager[]{TRUST_ALL_CERTS}, new SecureRandom());
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException("Failed to init SSL context", e);
+        }
+        SSLParameters params = new SSLParameters();
+        params.setEndpointIdentificationAlgorithm("");
+        client = HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .sslParameters(params)
+                .build();
+    }
+
+    private String authHeader() {
+        String tokenColon = SONAR_TOKEN + ":";
+        return "Basic " + Base64.getEncoder().encodeToString(tokenColon.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private JsonNode getJson(String path) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(SONAR_URL + path))
+                .header("Authorization", authHeader())
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new IOException("Request failed: " + response.statusCode());
+        }
+        return mapper.readTree(response.body());
+    }
+
+    private List<String> getProjects() throws IOException, InterruptedException {
+        JsonNode root = getJson("/api/projects/search?ps=500");
+        return root.path("components").findValuesAsText("key");
+    }
+
+    private Map<String, String> getMetrics(String projectKey) throws IOException, InterruptedException {
+        JsonNode root = getJson("/api/measures/component?component=" + projectKey + "&metricKeys=" + METRICS);
+        return StreamSupport.stream(root.path("component").path("measures").spliterator(), false)
+                .collect(Collectors.toMap(m -> m.path("metric").asText(), m -> m.path("value").asText()));
+    }
+
+    private void printHeader() {
+        System.out.println(String.join(",",
+                "project",
+                "coverage",
+                "duplicated_lines_density",
+                "reliability_rating",
+                "security_rating",
+                "sqale_rating",
+                "new_coverage",
+                "new_duplicated_lines_density",
+                "new_reliability_rating",
+                "new_security_rating",
+                "new_maintainability_rating"));
+    }
+
+    public void run() throws IOException, InterruptedException {
+        List<String> projects = getProjects();
+        printHeader();
+        for (String project : projects) {
+            Map<String, String> metrics = getMetrics(project);
+            System.out.println(String.join(",",
+                    project,
+                    metrics.getOrDefault("coverage", ""),
+                    metrics.getOrDefault("duplicated_lines_density", ""),
+                    metrics.getOrDefault("reliability_rating", ""),
+                    metrics.getOrDefault("security_rating", ""),
+                    metrics.getOrDefault("sqale_rating", ""),
+                    metrics.getOrDefault("new_coverage", ""),
+                    metrics.getOrDefault("new_duplicated_lines_density", ""),
+                    metrics.getOrDefault("new_reliability_rating", ""),
+                    metrics.getOrDefault("new_security_rating", ""),
+                    metrics.getOrDefault("new_maintainability_rating", "")));
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        new SonarMetricsFetcher().run();
+    }
+}


### PR DESCRIPTION
## Summary
- allow SonarMetricsFetcher to ignore SSL errors via custom TrustManager

## Testing
- `mvn -q package` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683ff8d8dca8832b9ea325eb2667310a